### PR TITLE
Fix case where params is undefined and spread

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ await client.torrent.multicall( 'active' )
     .send();
 
 /* Get the name, hash and label for all torrents */
-var result = await client.torrent.multicall()
+var result = await client.torrent.multiCall()
     .torrent.name()
     .torrent.hash()
     .torrent.getLabel()

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -26,9 +26,11 @@ class Serializer {
     dom_methodName.appendChild( doc.createTextNode( method ) );
 
     for ( var i = 0 ; i < params.length ; i += 1 ) {
+      if (params[i]) {
         var dom_param = doc.createElement('param');
         this.serializeValue(dom_param, params[i])
         dom_params.appendChild(dom_param)
+      }
     }
     return doc.toString();
   }


### PR DESCRIPTION
When we spread params who is undefined this creates an array with undefined has element `[undefined]` 

This fix is the easiest I found to avoid having to change a lot of code. 

Unit tests are not running I try on multiple node versions but nothing worked, do you have a special version and setup do make it work?